### PR TITLE
Optimization + inplace operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Example use:
     if b.Test(1000) {
     	b.Clear(1000)
     }
-    for i := b.NextSet(int64(0)); i >= 0; i = b.NextSet(i + 1) {
+    for i,e := v.NextSet(0); e; i,e = v.NextSet(i + 1) {
        frmt.Println("The following bit is set:",i);
     }
     if B.Intersection(bitset.New(100).Set(10)).Count() > 1 {

--- a/bitset.go
+++ b/bitset.go
@@ -51,6 +51,15 @@ import (
 	"math"
 )
 
+
+
+/////////////
+// Design issue: I think that a slice/array in Go has a length of type int
+// as per the spec http://golang.org/ref/spec#Length_and_capacity
+// yet this code assumes that the length is uint. I think that this is wrong
+//////////
+
+
 // Word size of a bit set
 const wordSize = uint(64)
 
@@ -71,11 +80,12 @@ type BitSetError string
 // fixup b.set to be non-nil and return the field value
 func (b *BitSet) safeSet() []uint64 {
 	if b.set == nil {
-		b.set = make([]uint64, wordsNeeded(0))
+		b.set = make([]uint64, wordsNeeded(0)) 
 	}
 	return b.set
 }
 
+// Daniel: I think this should return an int since this is the type used for array lengths in Go
 func wordsNeeded(i uint) uint {
 	if i > (math.MaxUint64 - wordSize + 1 ) { // safer?
 	// if i == math.MaxUint64 {
@@ -156,8 +166,8 @@ func (b *BitSet) Flip(i uint) *BitSet {
 }
 
 // return the next bit set from the specified index, including possibly the current index
-// returns -1 if none is found
-// inspired by the Java API: for i:=int64(0); i>=0; i = NextSet(i) {...}
+// along with an error code (true = valid, false = no set bit found)
+// for i,e := v.NextSet(0); e; i,e = v.NextSet(i + 1) {...}
 func (b *BitSet) NextSet(i uint) (uint,bool) {
 	x := i >> log2WordSize
 	if x >= b.length {
@@ -169,7 +179,7 @@ func (b *BitSet) NextSet(i uint) (uint,bool) {
 		return i + trailingZeroes64(w),true
 	}
 	x = x + 1
-	for x < wordsNeeded(b.length) {
+	for x < uint(len(b.set)) {
 		if b.set[x] != 0 {
 			return x * wordSize + trailingZeroes64(b.set[x]),true
 		}
@@ -189,6 +199,7 @@ func (b *BitSet) ClearAll() *BitSet {
 	return b
 }
 
+// Daniel: should return an int
 // Query words used in a bit set
 func (b *BitSet) wordCount() uint {
 	return wordsNeeded(b.length)
@@ -197,7 +208,9 @@ func (b *BitSet) wordCount() uint {
 // Clone this BitSet
 func (b *BitSet) Clone() *BitSet {
 	c := New(b.length)
-	copy(c.set, b.safeSet())
+	if b.set != nil {// Clone should not modify current object
+ 	  copy(c.set, b.set)
+	}
 	return c
 }
 
@@ -208,7 +221,9 @@ func (b *BitSet) Copy(c *BitSet) (count uint) {
 	if c == nil {
 		return
 	}
-	copy(c.set, b.safeSet())
+	if b.set != nil {// Copy should not modify current object
+	  copy(c.set, b.set)
+	}
 	count = c.length
 	if b.length < c.length {
 		count = b.length
@@ -292,7 +307,11 @@ func (b *BitSet) Equal(c *BitSet) bool {
 	if b.length != c.length {
 		return false
 	}
-	for p, v := range b.safeSet() {
+	if b.length == 0 { // if they have both length == 0, then could have nil set
+		return true
+	}
+	// testing for equality shoud not transform the bitset (no call to safeSet)
+	for p, v := range b.set {
 		if c.set[p] != v {
 			return false
 		}
@@ -312,15 +331,31 @@ func (b *BitSet) Difference(compare *BitSet) (result *BitSet) {
 	panicIfNull(b)
 	panicIfNull(compare)
 	result = b.Clone() // clone b (in case b is bigger than compare)
-	szl := compare.wordCount()
-	for i, word := range b.safeSet() {
-		if uint(i) >= szl {
-			break
-		}
-		result.set[i] = word &^ compare.set[i]
+	l := int(compare.wordCount()) 
+	if l > int(b.wordCount()) {
+		 l = int(b.wordCount())  
+	}
+	for i := 0; i < l ; i++ {
+	    result.set[i] = b.set[i] &^ compare.set[i]
 	}
 	return
 }
+
+// Difference of base set and other set
+// This is the BitSet equivalent of &^ (and not)
+func (b *BitSet) InPlaceDifference(compare *BitSet)  {
+	panicIfNull(b)
+	panicIfNull(compare)
+	l := int(compare.wordCount()) 
+	if l > int(b.wordCount()) {
+		 l = int(b.wordCount())  
+	}
+	for i := 0; i < l ; i++ {
+	    b.set[i] &^= compare.set[i]
+	}
+}
+
+
 
 // Convenience function: return two bitsets ordered by
 // increasing length. Note: neither can be nil
@@ -340,11 +375,34 @@ func (b *BitSet) Intersection(compare *BitSet) (result *BitSet) {
 	panicIfNull(compare)
 	b, compare = sortByLength(b, compare)
 	result = New(b.length)
-	for i, word := range b.safeSet() {
+	for i, word := range b.set {
 		result.set[i] = word & compare.set[i]
 	}
 	return
 }
+
+// Intersection of base set and other set
+// This is the BitSet equivalent of & (and)
+func (b *BitSet) InPlaceIntersection(compare *BitSet)  {
+	panicIfNull(b)
+	panicIfNull(compare)
+	l := int(compare.wordCount()) 
+	if l > int(b.wordCount()) {
+		 l = int(b.wordCount())  
+	}
+	for i := 0; i < l ; i++ {
+		b.set[i] &= compare.set[i]
+	}
+	for i := l; i < len(b.set) ; i++ {
+		b.set[i] = 0
+	}
+	if compare.length > 0 { 
+	  b.extendSetMaybe(compare.length - 1)
+	}
+	return
+}
+
+
 
 // Union of base set and other set
 // This is the BitSet equivalent of | (or)
@@ -353,14 +411,33 @@ func (b *BitSet) Union(compare *BitSet) (result *BitSet) {
 	panicIfNull(compare)
 	b, compare = sortByLength(b, compare)
 	result = compare.Clone()
-	szl := compare.wordCount()
-	for i, word := range b.safeSet() {
-		if uint(i) >= szl {
-			break
-		}
+	for i, word := range b.set {
 		result.set[i] = word | compare.set[i]
 	}
 	return
+}
+
+
+// Union of base set and other set
+// This is the BitSet equivalent of | (or)
+func (b *BitSet) InPlaceUnion(compare *BitSet)  {
+	panicIfNull(b)
+	panicIfNull(compare)
+	l := int(compare.wordCount()) 
+	if l > int(b.wordCount()) {
+		 l = int(b.wordCount())  
+	}
+	if compare.length > 0 { 
+	  b.extendSetMaybe(compare.length - 1)
+	}
+	for i := 0; i < l ; i++ {
+		b.set[i] |= compare.set[i]
+	}
+	if len(compare.set) > l  {
+	  for i := l; i < len(compare.set) ; i++ {
+		b.set[i] = compare.set[i]
+	  }
+	}
 }
 
 // SymmetricDifference of base set and other set
@@ -371,14 +448,32 @@ func (b *BitSet) SymmetricDifference(compare *BitSet) (result *BitSet) {
 	b, compare = sortByLength(b, compare)
 	// compare is bigger, so clone it
 	result = compare.Clone()
-	szl := b.wordCount()
-	for i, word := range b.safeSet() {
-		if uint(i) >= szl {
-			break
-		}
+	for i, word := range b.set {
 		result.set[i] = word ^ compare.set[i]
 	}
 	return
+}
+
+// SymmetricDifference of base set and other set
+// This is the BitSet equivalent of ^ (xor)
+func (b *BitSet) InPlaceSymmetricDifference(compare *BitSet)  {
+	panicIfNull(b)
+	panicIfNull(compare)
+	l := int(compare.wordCount()) 
+	if l > int(b.wordCount()) {
+		 l = int(b.wordCount())  
+	}
+	if compare.length > 0 { 
+	  b.extendSetMaybe(compare.length - 1)
+	}
+	for i := 0; i < l ; i++ {
+		b.set[i] ^= compare.set[i]
+	}
+	if len(compare.set) > l  {
+	  for i := l; i < len(compare.set) ; i++ {
+		b.set[i] = compare.set[i]
+	  }
+	}
 }
 
 // Is the length an exact multiple of word sizes?
@@ -397,7 +492,7 @@ func (b *BitSet) cleanLastWord() {
 func (b *BitSet) Complement() (result *BitSet) {
 	panicIfNull(b)
 	result = New(b.length)
-	for i, word := range b.safeSet() {
+	for i, word := range b.set {
 		result.set[i] = ^word
 	}
 	result.cleanLastWord()
@@ -431,9 +526,10 @@ func (b *BitSet) Any() bool {
 }
 
 // Dump as bits
+// if the bitset is empty, one word is automatically allocated
 func (b *BitSet) DumpAsBits() string {
 	buffer := bytes.NewBufferString("")
-	b.safeSet()
+	b.safeSet() // it is a bit odd that dumping as bits should modify the bitset!
 	i := int(wordsNeeded(b.length) - 1)
 	for ; i >= 0; i-- {
 		fmt.Fprintf(buffer, "%064b.", b.set[i])

--- a/bitset_test.go
+++ b/bitset_test.go
@@ -438,6 +438,32 @@ func TestUnion(t *testing.T) {
 	}
 }
 
+func TestInPlaceUnion(t *testing.T) {
+	a := New(100)
+	b := New(200)
+	for i := uint(1); i < 100; i += 2 {
+		a.Set(i)
+		b.Set(i - 1)
+	}
+	for i := uint(100); i < 200; i++ {
+		b.Set(i)
+	}
+	c := a.Clone()
+	c.InPlaceUnion(b)
+	d := b.Clone()
+	d.InPlaceUnion(a)
+	if c.Count() != 200 {
+		t.Errorf("Union should have 200 bits set, but had %d", c.Count())
+	}
+	if d.Count() != 200 {
+		t.Errorf("Union should have 200 bits set, but had %d", d.Count())
+	}
+	if !c.Equal(d) {
+		t.Errorf("Union should be symmetric")
+	}
+}
+
+
 func TestIntersection(t *testing.T) {
 	a := New(100)
 	b := New(200)
@@ -458,6 +484,33 @@ func TestIntersection(t *testing.T) {
 	}
 }
 
+
+func TestInplaceIntersection(t *testing.T) {
+	a := New(100)
+	b := New(200)
+	for i := uint(1); i < 100; i += 2 {
+		a.Set(i)
+		b.Set(i - 1).Set(i)
+	}
+	for i := uint(100); i < 200; i++ {
+		b.Set(i)
+	}
+	c := a.Clone()
+	c.InPlaceIntersection(b)
+	d := b.Clone()
+	d.InPlaceIntersection(a)
+	if c.Count() != 50 {
+		t.Errorf("Intersection should have 50 bits set, but had %d", c.Count())
+	}
+	if d.Count() != 50 {
+		t.Errorf("Intersection should have 50 bits set, but had %d", d.Count())
+	}
+	if !c.Equal(d) {
+		t.Errorf("Intersection should be symmetric")
+	}
+}
+
+
 func TestDifference(t *testing.T) {
 	a := New(100)
 	b := New(200)
@@ -474,7 +527,33 @@ func TestDifference(t *testing.T) {
 		t.Errorf("a-b Difference should have 50 bits set, but had %d", c.Count())
 	}
 	if d.Count() != 150 {
-		t.Errorf("b-a Difference should have 150 bits set, but had %d", c.Count())
+		t.Errorf("b-a Difference should have 150 bits set, but had %d", d.Count())
+	}
+	if c.Equal(d) {
+		t.Errorf("Difference, here, should not be symmetric")
+	}
+}
+
+
+func TestInPlaceDifference(t *testing.T) {
+	a := New(100)
+	b := New(200)
+	for i := uint(1); i < 100; i += 2 {
+		a.Set(i)
+		b.Set(i - 1)
+	}
+	for i := uint(100); i < 200; i++ {
+		b.Set(i)
+	}
+	c := a.Clone()
+	c.InPlaceDifference(b)
+	d := b.Clone()
+	d.InPlaceDifference(a)
+	if c.Count() != 50 {
+		t.Errorf("a-b Difference should have 50 bits set, but had %d", c.Count())
+	}
+	if d.Count() != 150 {
+		t.Errorf("b-a Difference should have 150 bits set, but had %d", d.Count())
 	}
 	if c.Equal(d) {
 		t.Errorf("Difference, here, should not be symmetric")
@@ -497,7 +576,32 @@ func TestSymmetricDifference(t *testing.T) {
 		t.Errorf("a^b Difference should have 150 bits set, but had %d", c.Count())
 	}
 	if d.Count() != 150 {
-		t.Errorf("b^a Difference should have 150 bits set, but had %d", c.Count())
+		t.Errorf("b^a Difference should have 150 bits set, but had %d", d.Count())
+	}
+	if !c.Equal(d) {
+		t.Errorf("SymmetricDifference should be symmetric")
+	}
+}
+
+func TestInPlaceSymmetricDifference(t *testing.T) {
+	a := New(100)
+	b := New(200)
+	for i := uint(1); i < 100; i += 2 {
+		a.Set(i)            // 01010101010 ... 0000000
+		b.Set(i - 1).Set(i) // 11111111111111111000000
+	}
+	for i := uint(100); i < 200; i++ {
+		b.Set(i)
+	}
+	c := a.Clone()
+	c.InPlaceSymmetricDifference(b)
+	d := b.Clone()
+	d.InPlaceSymmetricDifference(a)
+	if c.Count() != 150 {
+		t.Errorf("a^b Difference should have 150 bits set, but had %d", c.Count())
+	}
+	if d.Count() != 150 {
+		t.Errorf("b^a Difference should have 150 bits set, but had %d", d.Count())
 	}
 	if !c.Equal(d) {
 		t.Errorf("SymmetricDifference should be symmetric")


### PR DESCRIPTION
Points to consider:

1) I have added inplace operations. These can be very useful, as they can avoid an unnecessary copy. For fun, consider the case where you have two bloom filters, but you want to merge them. A simple in-place union would be best.

2) I suggest being conservative about modifying the object. For example, when calling "Equal", it is kind of surprising that the calling object would be modified. This could lead to evil bugs.

3) For the intersection, union... operations, you had a loop with an embedded if clause. I don't know if the compiler is smart enough to optimize this away. Maybe. Maybe not. I have rewritten the code so that you don't have to rely on having a smart compiler.

4) I have modified the NextSet function is that it is more Go-ish. I don't know whether it is better, faster... I did not benchmark it, but it feels nicer to me.

5) Though I have not fixed it, I think that there is a deeper design issue. My understanding is that we access slices/arrays using an int type index in Go. Slice lengths are similarly int-valued.  So you are doing a lot of messing around with uints, but this is not necessary, I think.
