### PR TITLE
Use pure Go popcount on App Engine

### DIFF
--- a/popcnt_asm.go
+++ b/popcnt_asm.go
@@ -1,4 +1,4 @@
-// +build amd64
+// +build amd64,!appengine
 
 package bitset
 

--- a/popcnt_generic.go
+++ b/popcnt_generic.go
@@ -1,4 +1,4 @@
-// +build !amd64
+// +build !amd64 appengine
 
 package bitset
 


### PR DESCRIPTION
App Engine doesn't allow assembly.  On that platform, use the pure Go
implementations of popcount functions.
