### PR TITLE
CopyFull: add func to duplicate a bitset to a target

### DIFF
--- a/bitset.go
+++ b/bitset.go
@@ -255,8 +255,8 @@ func (b *BitSet) Shrink(lastbitindex uint) *BitSet {
 	b.set = shrunk
 	b.length = length
 	if length < 64 {
-	  b.set[idx-1] &= (allBits >> (uint64(64) - uint64(length&(wordSize-1))))
-    }
+		b.set[idx-1] &= (allBits >> (uint64(64) - uint64(length&(wordSize-1))))
+	}
 	return b
 }
 

--- a/bitset.go
+++ b/bitset.go
@@ -542,6 +542,27 @@ func (b *BitSet) Copy(c *BitSet) (count uint) {
 	return
 }
 
+// CopyFull copies into a destination BitSet such that the destination is
+// identical to the source after the operation, allocating memory if necessary.
+func (b *BitSet) CopyFull(c *BitSet) {
+	if c == nil {
+		return
+	}
+	c.length = b.length
+	if len(b.set) == 0 {
+		if c.set != nil {
+			c.set = c.set[:0]
+		}
+	} else {
+		if cap(c.set) < len(b.set) {
+			c.set = make([]uint64, len(b.set))
+		} else {
+			c.set = c.set[:len(b.set)]
+		}
+		copy(c.set, b.set)
+	}
+}
+
 // Count (number of set bits).
 // Also known as "popcount" or "population count".
 func (b *BitSet) Count() uint {

--- a/bitset_test.go
+++ b/bitset_test.go
@@ -1425,6 +1425,22 @@ func TestCopy(t *testing.T) {
 	}
 }
 
+func TestCopyFull(t *testing.T) {
+	a := New(10)
+	b := &BitSet{}
+	a.CopyFull(b)
+	if b.length != a.length || len(b.set) != len(a.set) {
+		t.Error("Expected full length copy")
+		return
+	}
+	for i, v := range a.set {
+		if v != b.set[i] {
+			t.Error("Unexpected value")
+			return
+		}
+	}
+}
+
 func TestNextSetError(t *testing.T) {
 	b := new(BitSet)
 	c, d := b.NextSet(1)


### PR DESCRIPTION
Adds a new function to copy completely to a destination bitset.

This is because the Copy() function does not copy the lengths, so there is no way to do an in-place copy from another bitset.