### PR TITLE
Write data in chunk to prevent high memory usage when serializing

### DIFF
--- a/bitset.go
+++ b/bitset.go
@@ -227,7 +227,9 @@ func (b *BitSet) FlipRange(start, end uint) *BitSet {
 	b.extendSetMaybe(end - 1)
 	var startWord uint = start >> log2WordSize
 	var endWord uint = end >> log2WordSize
-	b.set[startWord] ^= ^(^uint64(0) << (start & (wordSize - 1)))
+	if end&(wordSize-1) != 0 {
+		b.set[endWord] ^= ^uint64(0) >> (-end & (wordSize - 1))
+	}
 	for i := startWord; i < endWord; i++ {
 		b.set[i] = ^b.set[i]
 	}

--- a/bitset_test.go
+++ b/bitset_test.go
@@ -1220,6 +1220,19 @@ func TestMarshalUnmarshalBinary(t *testing.T) {
 	}
 }
 
+func TestMarshalUnmarshalBinaryBig(t *testing.T) {
+	a := New(1048578).Set(10).Set(1048576).Set(1048577).Set(1048578)
+	b := new(BitSet)
+
+	copyBinary(t, a, b)
+
+	// BitSets must be equal after marshalling and unmarshalling
+	if !a.Equal(b) {
+		t.Error("Bitsets are not equal:\n\t", a.DumpAsBits(), "\n\t", b.DumpAsBits())
+		return
+	}
+}
+
 func TestMarshalUnmarshalBinaryByLittleEndian(t *testing.T) {
 	LittleEndian()
 	a := New(1010).Set(10).Set(1001)

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/bits-and-blooms/bitset
+module github.com/thanhpk/bitset
 
-go 1.14
+go 1.17


### PR DESCRIPTION
While writing a very big bitset (few GBs) into a file (`bitset.WriteTo`), the memory usage will be doubled, crashing the program.
This is because you are copying the whole data into another big []byte. 
This pull request fixs the issue by spliting data into smaller chunks then serialize each one into a reuseable buffer.
The memory usage is unchanged after calling `WriteTo`.