### PR TITLE
add SetBitsetFrom() to resolve #85

### DIFF
--- a/bitset.go
+++ b/bitset.go
@@ -87,6 +87,12 @@ func (b *BitSet) safeSet() []uint64 {
 	return b.set
 }
 
+// SetBitsetFrom fills the bitset with an array of integers without creating a new BitSet instance
+func (b *BitSet) SetBitsetFrom(buf []uint64) {
+	b.length = uint(len(buf)) * 64
+	b.set = buf
+}
+
 // From is a constructor used to create a BitSet from an array of integers
 func From(buf []uint64) *BitSet {
 	return FromWithLength(uint(len(buf))*64, buf)

--- a/bitset_test.go
+++ b/bitset_test.go
@@ -1308,6 +1308,18 @@ func TestSafeSet(t *testing.T) {
 	}
 }
 
+func TestSetBitsetFrom(t *testing.T) {
+	u := []uint64{2, 3, 5, 7, 11}
+	b := new(BitSet)
+	b.SetBitsetFrom(u)
+	outType := fmt.Sprintf("%T", b)
+	expType := "*bitset.BitSet"
+	if outType != expType {
+		t.Error("Expecting type: ", expType, ", gotf:", outType)
+		return
+	}
+}
+
 func TestFrom(t *testing.T) {
 	u := []uint64{2, 3, 5, 7, 11}
 	b := From(u)


### PR DESCRIPTION
This should close #85 .

Test results:
```shell
$ go test -cover
PASS
coverage: 89.7% of statements
ok      github.com/bits-and-blooms/bitset       0.121s
```