### PR TITLE
Fix over-reading while de-serializing

### DIFF
--- a/bitset.go
+++ b/bitset.go
@@ -945,11 +945,9 @@ func (b *BitSet) ReadFrom(stream io.Reader) (int64, error) {
 	// binary.Read for large set
 	reader := bufio.NewReader(stream)
 	var item = make([]byte, binary.Size(uint64(0))) // one uint64
-	for i := uint64(0); i < length; i++ {
+	nWords := uint64(wordsNeeded(uint(length)))
+	for i := uint64(0); i < nWords; i++ {
 		if _, err := reader.Read(item); err != nil {
-			if err == io.EOF {
-				break // done
-			}
 			return 0, err
 		}
 		newset.set[i] = binaryOrder.Uint64(item)

--- a/bitset_test.go
+++ b/bitset_test.go
@@ -1270,6 +1270,33 @@ func TestMarshalUnmarshalJSON(t *testing.T) {
 	}
 }
 
+func TestMarshalUnmarshalJSONWithTrailingData(t *testing.T) {
+	a := New(1010).Set(10).Set(1001)
+	data, err := json.Marshal(a)
+	if err != nil {
+		t.Errorf(err.Error())
+		return
+	}
+
+	// appending some noise
+	data = data[:len(data) - 3] // remove "
+	data = append(data, []byte(`AAAAAAAAAA"`)...)
+
+	b := new(BitSet)
+	err = json.Unmarshal(data, b)
+	if err != nil {
+		t.Errorf(err.Error())
+		return
+	}
+
+	// Bitsets must be equal after marshalling and unmarshalling
+	// Do not over-reading when unmarshalling
+	if !a.Equal(b) {
+		t.Error("Bitsets are not equal:\n\t", a.DumpAsBits(), "\n\t", b.DumpAsBits())
+		return
+	}
+}
+
 func TestMarshalUnmarshalJSONByStdEncoding(t *testing.T) {
 	Base64StdEncoding()
 	a := New(1010).Set(10).Set(1001)


### PR DESCRIPTION
The loop in the ReadFrom method has a wrong boundary condition. It should looping through word-length instead of bit-length.
If the input file has trailing data, it would over read and crash the program. See https://github.com/bits-and-blooms/bloom/issues/85.

This pull request fix the problem and add a test case to prove its correctness.