### PR TITLE
fix `ReadFrom` generate corrupted bitset when reader incompletely fills buf

### DIFF
--- a/bitset.go
+++ b/bitset.go
@@ -945,7 +945,7 @@ func (b *BitSet) ReadFrom(stream io.Reader) (int64, error) {
 	nWords := wordsNeeded(uint(length))
 	reader := bufio.NewReader(io.LimitReader(stream, 8*int64(nWords)))
 	for i := 0; i < nWords; i++ {
-		if _, err := reader.Read(item[:]); err != nil {
+		if _, err := io.ReadFull(reader, item[:]); err != nil {
 			if err == io.EOF {
 				err = io.ErrUnexpectedEOF
 			}


### PR DESCRIPTION
`io.Read` does not guarantee read len(p) bytes. 
> Read reads up to len(p) bytes into p. It returns the number of bytes read (0 <= n <= len(p)) and any error encountered. Even if Read returns n < len(p), it may use all of p as scratch space during the call. **If some data is available but not len(p) bytes, Read conventionally returns what is available instead of waiting for more.**