### PR TITLE
Clean last word of target bitset after using Copy.

### DIFF
--- a/bitset.go
+++ b/bitset.go
@@ -556,6 +556,9 @@ func (b *BitSet) Copy(c *BitSet) (count uint) {
 	if b.length < c.length {
 		count = b.length
 	}
+	// Cleaning the last word is needed to keep the invariant that other functions, such as Count, require
+	// that any bits in the last word that would exceed the length of the bitmask are set to 0.
+	c.cleanLastWord()
 	return
 }
 

--- a/bitset_test.go
+++ b/bitset_test.go
@@ -1486,6 +1486,34 @@ func TestCopy(t *testing.T) {
 	}
 }
 
+func TestCopyUnaligned(t *testing.T) {
+	a := New(16)
+	a.FlipRange(0, 16)
+	b := New(1)
+	a.Copy(b)
+	if b.Count() > b.Len() {
+		t.Errorf("targets copied set count (%d) should never be larger than target's length (%d)", b.Count(), b.Len())
+	}
+	if !b.Test(0) {
+		t.Errorf("first bit should still be set in copy: %+v", b)
+	}
+
+	// Test a more complex scenario with a mix of bits set in the unaligned space to verify no bits are lost.
+	a = New(32)
+	a.Set(0).Set(3).Set(4).Set(16).Set(17).Set(29).Set(31)
+	b = New(19)
+	a.Copy(b)
+
+	const expectedCount = 5
+	if b.Count() != expectedCount {
+		t.Errorf("targets copied set count: %d, want %d", b.Count(), expectedCount)
+	}
+
+	if !(b.Test(0) && b.Test(3) && b.Test(4) && b.Test(16) && b.Test(17)) {
+		t.Errorf("expected set bits are not set: %+v", b)
+	}
+}
+
 func TestCopyFull(t *testing.T) {
 	a := New(10)
 	b := &BitSet{}


### PR DESCRIPTION
# Description

This PR will use the existing cleanLastWord when copying a bitset to keep the invariant other functions depend on, such as Count, that no bits are set past the length of the bitmask on the last uint64 word. 

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #112 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

A new TestCopyUnaligned unit test has been added which verifies that a new bitmask copy that isn't aligned on a 64 bit copies from a bitmask that is larger, but only by less than a uint64 word, that Count and the set bits in the copy are correct.  Without the change, this test will fail where the targets Count() would be > than the length of the target.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] (NA) I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (NA) Any dependent changes have been merged and published in downstream modules