### PR TITLE
Eliminate some allocations in ReadFrom/WriteTo

### DIFF
--- a/bitset_benchmark_test.go
+++ b/bitset_benchmark_test.go
@@ -7,6 +7,7 @@
 package bitset
 
 import (
+	"bytes"
 	"math/rand"
 	"testing"
 )
@@ -443,5 +444,20 @@ func BenchmarkFlorianUekermannMidStrongDensityIterateManyComp(b *testing.B) {
 	}
 	if checksum == 0 { // added just to fool ineffassign
 		return
+	}
+}
+
+func BenchmarkBitsetReadWrite(b *testing.B) {
+	s := New(100000)
+	for i := 0; i < 100000; i += 100 {
+		s.Set(uint(i))
+	}
+	buffer := bytes.Buffer{}
+	temp := New(100000)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		s.WriteTo(&buffer)
+		temp.ReadFrom(&buffer)
+		buffer.Reset()
 	}
 }


### PR DESCRIPTION
Fixes #123 

Before 

`BenchmarkBitsetReadWrite-16        33740             52474 ns/op            8409 B/op         12 allocs/op`

After

`BenchmarkBitsetReadWrite-16        55478             21935 ns/op              16 B/op          2 allocs/op`

