### PR TITLE
Add Security Policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -10,7 +10,7 @@ If you have discovered a security vulnerability in this project, please report i
 
 Please use the following contact information for reporting a vulnerability:
 
-- [Daniel Lemire](https://github.com/lemire) - [daniel@lemire.me](mailto:email@example.com)
+- [Daniel Lemire](https://github.com/lemire) - [daniel@lemire.me](mailto:daniel@lemire.me)
 
 In your report, please include:
 

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Policy
+
+## Supported Versions
+
+Security updates are applied only to the latest release.
+
+## Reporting a Vulnerability
+
+If you have discovered a security vulnerability in this project, please report it privately. **Do not disclose it as a public issue.** This gives us time to work with you to fix the issue before public exposure, reducing the chance that the exploit will be used before a patch is released.
+
+Please use the following contact information for reporting a vulnerability:
+
+- [Daniel Lemire](https://github.com/lemire) - [daniel@lemire.me](mailto:email@example.com)
+
+In your report, please include:
+
+- A description of the vulnerability and its impact
+- How to reproduce the it
+- Affected versions
+
+This project is maintained by a team of volunteers on a reasonable-effort basis. As such, please give us at least 90 days to work on a fix before public exposure.


### PR DESCRIPTION
Resolves https://github.com/bits-and-blooms/bitset/issues/126

Here's a Security Policy suggestion. Let me know what you think and if this seems reasonable for maintenance.

Also, FYI, GitHub has a beta feature for [reporting vulnerabilities](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability) too if you'd like to take a look.