### PR TITLE
Reference actions by commit SHA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Install Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe #v4.1.0
       with:
         go-version: ${{ matrix.go-version }}
     - name: Checkout code
-      uses: actions/checkout@master
+      uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac #v4.0.0
     - name: Test
       run: go test ./...


### PR DESCRIPTION
Resolves https://github.com/bits-and-blooms/bitset/issues/135

It's important to make sure the SHA's are from the original repositories and not forks. I have manually verified all of them and added references in the commit description.