### PR TITLE
Fix MarshalJSON not working for values

### DIFF
--- a/bitset.go
+++ b/bitset.go
@@ -1019,7 +1019,7 @@ func (b *BitSet) UnmarshalBinary(data []byte) error {
 }
 
 // MarshalJSON marshals a BitSet as a JSON structure
-func (b *BitSet) MarshalJSON() ([]byte, error) {
+func (b BitSet) MarshalJSON() ([]byte, error) {
 	buffer := bytes.NewBuffer(make([]byte, 0, b.BinaryStorageSize()))
 	_, err := b.WriteTo(buffer)
 	if err != nil {

--- a/bitset_test.go
+++ b/bitset_test.go
@@ -1297,25 +1297,49 @@ func copyBinary(t *testing.T, from encoding.BinaryMarshaler, to encoding.BinaryU
 }
 
 func TestMarshalUnmarshalJSON(t *testing.T) {
-	a := New(1010).Set(10).Set(1001)
-	data, err := json.Marshal(a)
-	if err != nil {
-		t.Errorf(err.Error())
-		return
-	}
+	t.Run("value", func(t *testing.T) {
+		a := BitSet{}
+		a.Set(10).Set(1001)
+		data, err := json.Marshal(a)
+		if err != nil {
+			t.Errorf(err.Error())
+			return
+		}
 
-	b := new(BitSet)
-	err = json.Unmarshal(data, b)
-	if err != nil {
-		t.Errorf(err.Error())
-		return
-	}
+		b := new(BitSet)
+		err = json.Unmarshal(data, b)
+		if err != nil {
+			t.Errorf(err.Error())
+			return
+		}
 
-	// Bitsets must be equal after marshalling and unmarshalling
-	if !a.Equal(b) {
-		t.Error("Bitsets are not equal:\n\t", a.DumpAsBits(), "\n\t", b.DumpAsBits())
-		return
-	}
+		// Bitsets must be equal after marshalling and unmarshalling
+		if !a.Equal(b) {
+			t.Error("Bitsets are not equal:\n\t", a.DumpAsBits(), "\n\t", b.DumpAsBits())
+			return
+		}
+	})
+	t.Run("pointer", func(t *testing.T) {
+		a := New(1010).Set(10).Set(1001)
+		data, err := json.Marshal(a)
+		if err != nil {
+			t.Errorf(err.Error())
+			return
+		}
+
+		b := new(BitSet)
+		err = json.Unmarshal(data, b)
+		if err != nil {
+			t.Errorf(err.Error())
+			return
+		}
+
+		// Bitsets must be equal after marshalling and unmarshalling
+		if !a.Equal(b) {
+			t.Error("Bitsets are not equal:\n\t", a.DumpAsBits(), "\n\t", b.DumpAsBits())
+			return
+		}
+	})
 }
 
 func TestMarshalUnmarshalJSONWithTrailingData(t *testing.T) {


### PR DESCRIPTION
Marshalling a non pointer BitSets results in an empty JSON object:
```
var bs bitset.BitSet
bs.Set(0)
bytes, _ := json.Marshal(bs)
fmt.Println(string(bytes))
```

To fix this the BitSet.MarshalJSON method needs to be a value receiver instead of a pointer receiver.