### PR TITLE
 Add dependabot to monitor GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Fixes #145.

This PR sets up dependabot to send a single monthly PR updating all Actions with new versions. It will update both the hashes and their respective version comments (see [this example](https://github.com/pnacht/libarchive/pull/11)).