### PR TITLE
len64() - fix docstring, tests for go1.8

### DIFF
--- a/leading_zeros_18.go
+++ b/leading_zeros_18.go
@@ -39,5 +39,5 @@ func len64(x uint64) (n uint) {
 }
 
 func leadingZeroes64(v uint64) uint {
-	return 64 - len64(x)
+	return 64 - len64(v)
 }

--- a/leading_zeros_18.go
+++ b/leading_zeros_18.go
@@ -21,7 +21,7 @@ var len8tab = "" +
 	"\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08" +
 	"\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08"
 
-// Len64 returns the minimum number of bits required to represent x; the result is 0 for x == 0.
+// len64 returns the minimum number of bits required to represent x; the result is 0 for x == 0.
 func len64(x uint64) (n uint) {
 	if x >= 1<<32 {
 		x >>= 32

--- a/leading_zeros_test.go
+++ b/leading_zeros_test.go
@@ -1,0 +1,18 @@
+//go:build !go1.9
+// +build !go1.9
+
+package bitset
+
+import (
+	"testing"
+)
+
+func TestLen64(t *testing.T) {
+	for i := 0; i < 64; i++ {
+		received := len64(uint64(1) << i)
+		expected := uint(i + 1)
+		if received != expected {
+			t.Errorf("len64(%b) is incorrect: received %d, expected %d", uint64(1)<<i, received, expected)
+		}
+	}
+}


### PR DESCRIPTION
- fixes docstring typo https://github.com/bits-and-blooms/bitset/issues/167 
- adds sanity tests for `len64()` as requested in https://github.com/bits-and-blooms/bitset/pull/165
- fixes typo in unused `leadingZeroes64()` for go1.8