### PR TITLE
add inlineable bitset.MustNew

### DIFF
--- a/bitset.go
+++ b/bitset.go
@@ -147,6 +147,15 @@ func New(length uint) (bset *BitSet) {
 	return bset
 }
 
+// MustNew creates a new BitSet with a hint that length bits will be required,
+// it panics if you exceed the capacity.
+func MustNew(length uint) (bset *BitSet) {
+	return &BitSet{
+		length,
+		make([]uint64, wordsNeeded(length)),
+	}
+}
+
 // Cap returns the total possible capacity, or number of bits
 // that can be stored in the BitSet. Note that this is further limited
 // by the maximum allocation size in Go, and your available memory,

--- a/bitset_benchmark_test.go
+++ b/bitset_benchmark_test.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 )
 
+var sinkBitSet *BitSet
+
 func BenchmarkSet(b *testing.B) {
 	b.StopTimer()
 	r := rand.New(rand.NewSource(0))
@@ -615,5 +617,19 @@ func BenchmarkIsSuperSet(b *testing.B) {
 			len, len, density, overrideS, overrideSS, f)
 		bench(fmt.Sprintf("superset, len=%d, diff=%d, strict", len, diff),
 			len, len, density, overrideS, overrideSS, fStrict)
+	}
+}
+
+func BenchmarkNew(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sinkBitSet = New(0)
+	}
+}
+
+func BenchmarkMustNew(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sinkBitSet = MustNew(0)
 	}
 }


### PR DESCRIPTION
maybe you have to improve the docstring since I'm no native speaker.

MustNew() is now inlineable with cost 38

```text
./bitset.go:133:8: cannot inline New.func1: call to recover
./bitset.go:152:6: can inline MustNew with cost 36 as: func(uint) *BitSet { return &BitSet{...} }
```
I added a simple benchmark, you can just drop it:
```text
$ go test -run=xxx -bench=New -benchmem -cpu=1
goos: linux
goarch: amd64
pkg: github.com/bits-and-blooms/bitset
cpu: Intel(R) Core(TM) i5-8250U CPU @ 1.60GHz
BenchmarkNew     	18782474	        54.59 ns/op	      32 B/op	       1 allocs/op
BenchmarkMustNew 	21782233	        46.69 ns/op	      32 B/op	       1 allocs/op
PASS
ok  	github.com/bits-and-blooms/bitset	2.169s
```

thanks a lot for `bitset`!