### PR TITLE
Add the method EachSet for more convenient use and better performance

### DIFF
--- a/bitset.go
+++ b/bitset.go
@@ -44,6 +44,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"iter"
 	"math/bits"
 	"strconv"
 )
@@ -562,6 +563,21 @@ func (b *BitSet) AsSlice(buf []uint) []uint {
 
 	buf = buf[:size]
 	return buf
+}
+
+// EachSet returns an iterator over all set bits in the BitSet.
+func (b *BitSet) EachSet() iter.Seq[uint] {
+	return func(yield func(uint) bool) {
+		for wordIndex, word := range b.set {
+			idx := 0
+			for trail := bits.TrailingZeros64(word); trail != 64; trail = bits.TrailingZeros64(word >> idx) {
+				if !yield(uint(wordIndex<<log2WordSize + idx + trail)) {
+					return
+				}
+				idx += trail + 1
+			}
+		}
+	}
 }
 
 // NextSet returns the next bit set from the specified index,

--- a/bitset_benchmark_test.go
+++ b/bitset_benchmark_test.go
@@ -59,7 +59,7 @@ func BenchmarkCount(b *testing.B) {
 	}
 }
 
-// go test -bench=Iterate
+// go test -bench=BenchmarkIter
 func BenchmarkIterate(b *testing.B) {
 	b.StopTimer()
 	s := New(10000)
@@ -70,6 +70,21 @@ func BenchmarkIterate(b *testing.B) {
 	for j := 0; j < b.N; j++ {
 		c := uint(0)
 		for i, e := s.NextSet(0); e; i, e = s.NextSet(i + 1) {
+			c++
+		}
+	}
+}
+
+func BenchmarkIter(b *testing.B) {
+	b.StopTimer()
+	s := New(10000)
+	for i := 0; i < 10000; i += 3 {
+		s.Set(uint(i))
+	}
+	b.StartTimer()
+	for j := 0; j < b.N; j++ {
+		c := uint(0)
+		for range s.EachSet() {
 			c++
 		}
 	}

--- a/bitset_test.go
+++ b/bitset_test.go
@@ -3035,3 +3035,11 @@ func BenchmarkBitSetExtractDeposit(b *testing.B) {
 		})
 	}
 }
+
+func TestIter(t *testing.T) {
+	var b BitSet
+	b.Set(0).Set(3).Set(5).Set(6).Set(63).Set(64).Set(65).Set(127).Set(128).Set(1000000)
+	for i := range b.EachSet() {
+		fmt.Println(i)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/bits-and-blooms/bitset
 
-go 1.16
+go 1.23


### PR DESCRIPTION
Compared to `for i, e := v.NextSet(0); e; i, e = v.NextSet(i + 1) {...}` , `for range s.EachSet() {...}` provides clearer semantics and better iteration performance.