### PR TITLE
make Rank() inlineable

### DIFF
--- a/bitset_benchmark_test.go
+++ b/bitset_benchmark_test.go
@@ -658,3 +658,19 @@ func BenchmarkClearRMS(b *testing.B) {
 		}
 	})
 }
+
+// go test -bench=Rank
+func BenchmarkRank(b *testing.B) {
+	s := New(100000)
+	for i := 0; i < 100000; i += 100 {
+		s.Set(uint(i))
+	}
+	for _, u := range []uint{1, 20, 50, 100, 200, 500, 1_000, 10_000, 20_000, 50_000, 100_000, 200_000} {
+		b.Run(fmt.Sprintf("Rank(%d)", u), func(b *testing.B) {
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = s.Rank(u)
+			}
+		})
+	}
+}


### PR DESCRIPTION
old: ./bitset.go:1388:6: cannot inline (*BitSet).Rank: function too complex: cost 106 exceeds budget 80
new: ./bitset.go:1388:6: can inline (*BitSet).Rank with cost 75

$ benchstat rank.old rank.new
goos: linux
goarch: amd64
pkg: github.com/bits-and-blooms/bitset
cpu: Intel(R) Core(TM) i5-8250U CPU @ 1.60GHz
                  │  rank.old   │              rank.new              │
                  │   sec/op    │   sec/op     vs base               │
Rank/Rank(1)        3.168n ± 1%   1.232n ± 2%  -61.10% (p=0.002 n=6)
Rank/Rank(20)       3.165n ± 0%   1.224n ± 1%  -61.34% (p=0.002 n=6)
Rank/Rank(50)       3.169n ± 2%   1.252n ± 2%  -60.50% (p=0.002 n=6)
Rank/Rank(100)      3.607n ± 2%   2.371n ± 1%  -34.28% (p=0.002 n=6)
Rank/Rank(200)      4.492n ± 0%   3.594n ± 0%  -20.00% (p=0.002 n=6)
Rank/Rank(500)      6.010n ± 1%   4.806n ± 0%  -20.03% (p=0.002 n=6)
Rank/Rank(1000)     9.538n ± 0%   7.724n ± 0%  -19.02% (p=0.002 n=6)
Rank/Rank(10000)    77.26n ± 1%   56.96n ± 2%  -26.26% (p=0.002 n=6)
Rank/Rank(20000)    145.9n ± 2%   103.6n ± 0%  -28.99% (p=0.002 n=6)
Rank/Rank(50000)    351.2n ± 0%   244.2n ± 0%  -30.48% (p=0.002 n=6)
Rank/Rank(100000)   699.6n ± 0%   478.5n ± 5%  -31.60% (p=0.002 n=6)
Rank/Rank(200000)   699.1n ± 0%   478.3n ± 0%  -31.59% (p=0.002 n=6)
geomean             24.91n        15.53n       -37.66%