### PR TITLE
minimize inlining cost and code complexity

### DIFF
--- a/popcnt.go
+++ b/popcnt.go
@@ -2,58 +2,41 @@ package bitset
 
 import "math/bits"
 
-func popcntSlice(s []uint64) uint64 {
-	var cnt int
+func popcntSlice(s []uint64) (cnt uint64) {
 	for _, x := range s {
-		cnt += bits.OnesCount64(x)
+		cnt += uint64(bits.OnesCount64(x))
 	}
-	return uint64(cnt)
+	return
 }
 
-func popcntMaskSlice(s, m []uint64) uint64 {
-	var cnt int
-	// this explicit check eliminates a bounds check in the loop
-	if len(m) < len(s) {
-		panic("mask slice is too short")
-	}
+func popcntMaskSlice(s, m []uint64) (cnt uint64) {
+	_ = m[len(s)-1] // BCE
 	for i := range s {
-		cnt += bits.OnesCount64(s[i] &^ m[i])
+		cnt += uint64(bits.OnesCount64(s[i] &^ m[i]))
 	}
-	return uint64(cnt)
+	return
 }
 
-func popcntAndSlice(s, m []uint64) uint64 {
-	var cnt int
-	// this explicit check eliminates a bounds check in the loop
-	if len(m) < len(s) {
-		panic("mask slice is too short")
-	}
+func popcntAndSlice(s, m []uint64) (cnt uint64) {
+	_ = m[len(s)-1] // BCE
 	for i := range s {
-		cnt += bits.OnesCount64(s[i] & m[i])
+		cnt += uint64(bits.OnesCount64(s[i] & m[i]))
 	}
-	return uint64(cnt)
+	return
 }
 
-func popcntOrSlice(s, m []uint64) uint64 {
-	var cnt int
-	// this explicit check eliminates a bounds check in the loop
-	if len(m) < len(s) {
-		panic("mask slice is too short")
-	}
+func popcntOrSlice(s, m []uint64) (cnt uint64) {
+	_ = m[len(s)-1] // BCE
 	for i := range s {
-		cnt += bits.OnesCount64(s[i] | m[i])
+		cnt += uint64(bits.OnesCount64(s[i] | m[i]))
 	}
-	return uint64(cnt)
+	return
 }
 
-func popcntXorSlice(s, m []uint64) uint64 {
-	var cnt int
-	// this explicit check eliminates a bounds check in the loop
-	if len(m) < len(s) {
-		panic("mask slice is too short")
-	}
+func popcntXorSlice(s, m []uint64) (cnt uint64) {
+	_ = m[len(s)-1] // BCE
 	for i := range s {
-		cnt += bits.OnesCount64(s[i] ^ m[i])
+		cnt += uint64(bits.OnesCount64(s[i] ^ m[i]))
 	}
-	return uint64(cnt)
+	return
 }


### PR DESCRIPTION
@lemire use the PR or close it as you like:

no explizit call of panic() for BCE, asm code is now `nosplit`, no stack growth needed

OLD:
```
can inline popcntMaskSlice with cost 32
can inline popcntAndSlice with cost 32
can inline popcntOrSlice with cost 32
can inline popcntXorSlice with cost 32
```

```
github.com/bits-and-blooms/bitset.popcntMaskSlice STEXT size=165 args=0x30 locals=0x18 funcid=0x0 align=0x0
github.com/bits-and-blooms/bitset.popcntAndSlice STEXT size=158 args=0x30 locals=0x18 funcid=0x0 align=0x0
github.com/bits-and-blooms/bitset.popcntOrSlice STEXT size=158 args=0x30 locals=0x18 funcid=0x0 align=0x0
github.com/bits-and-blooms/bitset.popcntXorSlice STEXT size=158 args=0x30 locals=0x18 funcid=0x0 align=0x0
```
NEW:
```
can inline popcntMaskSlice with cost 26
can inline popcntAndSlice with cost 26
can inline popcntOrSlice with cost 26
can inline popcntXorSlice with cost 26
```

```
github.com/bits-and-blooms/bitset.popcntMaskSlice STEXT nosplit size=82 args=0x30 locals=0x18 funcid=0x0 align=0x0
github.com/bits-and-blooms/bitset.popcntAndSlice STEXT nosplit size=79 args=0x30 locals=0x18 funcid=0x0 align=0x0
github.com/bits-and-blooms/bitset.popcntOrSlice STEXT nosplit size=79 args=0x30 locals=0x18 funcid=0x0 align=0x0
github.com/bits-and-blooms/bitset.popcntXorSlice STEXT nosplit size=79 args=0x30 locals=0x18 funcid=0x0 align=0x0
```