### PR TITLE
fixed UnionCardinality panic on empty bitsets

### DIFF
--- a/bitset_test.go
+++ b/bitset_test.go
@@ -1302,6 +1302,14 @@ func TestUnion(t *testing.T) {
 	}
 }
 
+func TestEmptyUnionCardinality(t *testing.T) {
+	a := New(0)
+	b := New(0)
+	if a.UnionCardinality(b) != 0 {
+		t.Error("UnionCardinality should be zero")
+	}
+}
+
 func TestInPlaceUnion(t *testing.T) {
 	a := New(100)
 	b := New(200)
@@ -1350,6 +1358,14 @@ func TestIntersection(t *testing.T) {
 	}
 	if !c.Equal(d) {
 		t.Errorf("Intersection should be symmetric")
+	}
+}
+
+func TestEmptyIntersectionCardinality(t *testing.T) {
+	a := New(0)
+	b := New(0)
+	if a.IntersectionCardinality(b) != 0 {
+		t.Error("IntersectionCardinality should be zero")
 	}
 }
 
@@ -1408,6 +1424,14 @@ func TestDifference(t *testing.T) {
 	}
 }
 
+func TestEmptyDifferenceCardinality(t *testing.T) {
+	a := New(0)
+	b := New(0)
+	if a.DifferenceCardinality(b) != 0 {
+		t.Error("DifferenceCardinality should be zero")
+	}
+}
+
 func TestInPlaceDifference(t *testing.T) {
 	a := New(100)
 	b := New(200)
@@ -1460,6 +1484,14 @@ func TestSymmetricDifference(t *testing.T) {
 	}
 	if !c.Equal(d) {
 		t.Errorf("SymmetricDifference should be symmetric")
+	}
+}
+
+func TestEmptySymmetricDifferenceCardinality(t *testing.T) {
+	a := New(0)
+	b := New(0)
+	if a.SymmetricDifferenceCardinality(b) != 0 {
+		t.Error("SymmetricDifferenceCardinality should be zero")
 	}
 }
 

--- a/popcnt.go
+++ b/popcnt.go
@@ -10,7 +10,6 @@ func popcntSlice(s []uint64) (cnt uint64) {
 }
 
 func popcntMaskSlice(s, m []uint64) (cnt uint64) {
-	_ = m[len(s)-1] // BCE
 	for i := range s {
 		cnt += uint64(bits.OnesCount64(s[i] &^ m[i]))
 	}
@@ -18,7 +17,6 @@ func popcntMaskSlice(s, m []uint64) (cnt uint64) {
 }
 
 func popcntAndSlice(s, m []uint64) (cnt uint64) {
-	_ = m[len(s)-1] // BCE
 	for i := range s {
 		cnt += uint64(bits.OnesCount64(s[i] & m[i]))
 	}
@@ -26,7 +24,6 @@ func popcntAndSlice(s, m []uint64) (cnt uint64) {
 }
 
 func popcntOrSlice(s, m []uint64) (cnt uint64) {
-	_ = m[len(s)-1] // BCE
 	for i := range s {
 		cnt += uint64(bits.OnesCount64(s[i] | m[i]))
 	}
@@ -34,7 +31,6 @@ func popcntOrSlice(s, m []uint64) (cnt uint64) {
 }
 
 func popcntXorSlice(s, m []uint64) (cnt uint64) {
-	_ = m[len(s)-1] // BCE
 	for i := range s {
 		cnt += uint64(bits.OnesCount64(s[i] ^ m[i]))
 	}


### PR DESCRIPTION
# Description

`UnionCardinality`, `IntersectionCardinality`, `DifferenceCardinality`, `SymmetricDifferenceCardinality` panic on an empty bitset with "index out of range". Minimal example:
```go
a := New(0)
b := New(0)
_ = a.UnionCardinality(b)
```
panic is "commutative", i.e. `a` and `b` may be swapped. 

# Fix

 Remove all `_ = m[len(s)-1] // BCE` in popcnt*Slice functions introduced in #203.

Additionally, I wasn't able to reproduce any gain in inlining cost, but this might be due to the different go version I use (1.24).