### PR TITLE
fixed ShiftLeft panic

### DIFF
--- a/bitset.go
+++ b/bitset.go
@@ -1473,7 +1473,7 @@ func (b *BitSet) ShiftLeft(bits uint) {
 	dst := b.set
 
 	// not using extendSet() to avoid unneeded data copying
-	nsize := wordsNeeded(top + bits)
+	nsize := wordsNeeded(top + bits + 1)
 	if len(b.set) < nsize {
 		dst = make([]uint64, nsize)
 	}

--- a/bitset_test.go
+++ b/bitset_test.go
@@ -2330,7 +2330,7 @@ func TestSetAll(t *testing.T) {
 }
 
 func TestShiftLeft(t *testing.T) {
-	data := []uint{5, 28, 45, 72, 89}
+	data := []uint{5, 28, 45, 72, 89, 560}
 
 	test := func(name string, bits uint) {
 		t.Run(name, func(t *testing.T) {
@@ -2360,6 +2360,7 @@ func TestShiftLeft(t *testing.T) {
 	test("no page split", 80)
 	test("with page split", 114)
 	test("with extension", 242)
+	test("with extra word", 16)
 }
 
 func TestShiftRight(t *testing.T) {


### PR DESCRIPTION
# Description

In some rare cases `ShiftLeft` panics in bitset.go#1490. Minimal example:
```go
a := New(0)
a.Set(560)
a.ShiftLeft(16) // panic
```

# Fix 

I believe this is just "off by one" error in the calculation of the needed size. I didn't dig much deeper, so it's possible that this bug has a better fix.

A value that caused panic is added into `TestShiftLeft`, hovewer this case could be minified if needed. 