### PR TITLE
fix off by 1 error in ShiftRight

### DIFF
--- a/bitset.go
+++ b/bitset.go
@@ -1531,7 +1531,7 @@ func (b *BitSet) ShiftRight(bits uint) {
 		return
 	}
 
-	if bits >= top {
+	if bits > top {
 		b.set = make([]uint64, wordsNeeded(b.length))
 		return
 	}

--- a/bitset_test.go
+++ b/bitset_test.go
@@ -2409,7 +2409,7 @@ func TestShiftRight(t *testing.T) {
 
 			count := 0
 			for _, i := range data {
-				if i > bits {
+				if i >= bits {
 					count++
 
 					if !b.Test(i - bits) {
@@ -2419,7 +2419,7 @@ func TestShiftRight(t *testing.T) {
 			}
 
 			if int(b.Count()) != count {
-				t.Error("bad bits count")
+				t.Errorf("bad bits count: expected %d, got %d", count, b.Count())
 			}
 		})
 	}
@@ -2432,6 +2432,43 @@ func TestShiftRight(t *testing.T) {
 	test("with extension", 70)
 	test("full shift", 89)
 	test("remove all", 242)
+}
+
+func TestShiftRightFull(t *testing.T) {
+	testCases := []struct{
+		data []uint
+		shiftDistance uint
+	}{
+		{
+			[]uint{20}, 20,
+		},
+		{
+			[]uint{0, 20, 40, 1260, 1280}, 1,
+		},
+		{
+			[]uint{0, 20, 40, 1260, 1280}, 1281,
+		},
+	}
+
+	test := func(data []uint, shiftDistance uint) {
+		b := New(0)
+		for i := range data {
+			b.Set(data[i])
+		}
+		b.ShiftRight(shiftDistance)
+		for i := range data {
+			shiftedBit := int(data[i])-int(shiftDistance)
+			if shiftedBit >= 0 {
+				if !b.Test(uint(shiftedBit)) {
+					t.Errorf("bit %d should be set after ShiftRight(%d) if bit %d was set prior", data[i]-shiftDistance, shiftDistance, data[i])
+				}
+			}
+		}
+	}
+
+	for i := range testCases {
+		test(testCases[i].data, testCases[i].shiftDistance)
+	}
 }
 
 func TestWord(t *testing.T) {


### PR DESCRIPTION
# Description

```go
b := New(0)
b.Set(N)
b.ShiftRight(N) // expect to have the zero bit set, as (2^N) >> N == 1
b.Test(0) // false...
```

# Fix

It seems like an off by one error in `ShiftRight`. We should empty the set iff the shift distance exceeds the number of top set bit. When the shift distance equals to the top set bit, that is the only bit what is left after the shift.
It also required adjusting one existing test case. 