### PR TITLE
test: raise coverage with edge-case tests, pextgen tests, and godoc examples

### DIFF
--- a/bitset_iter_test.go
+++ b/bitset_iter_test.go
@@ -41,6 +41,24 @@ func TestIter(t *testing.T) {
 		t.Errorf("Got extra values: %v", got[len(expected):])
 	}
 }
+
+func TestIterEarlyStop(t *testing.T) {
+	var b BitSet
+	b.Set(2).Set(7).Set(90)
+
+	got := make([]uint, 0)
+	for i := range b.EachSet() {
+		got = append(got, i)
+		if len(got) == 2 {
+			break
+		}
+	}
+
+	if len(got) != 2 || got[0] != 2 || got[1] != 7 {
+		t.Errorf("Expected [2 7], got %v", got)
+	}
+}
+
 func BenchmarkIter(b *testing.B) {
 	b.StopTimer()
 	s := New(10000)

--- a/bitset_test.go
+++ b/bitset_test.go
@@ -3104,3 +3104,348 @@ func BenchmarkBitSetExtractDeposit(b *testing.B) {
 		})
 	}
 }
+
+func TestBinaryOrder(t *testing.T) {
+	defer func() {
+		binaryOrder = binary.BigEndian
+	}()
+
+	if BinaryOrder() != binary.BigEndian {
+		t.Error("expected the default binary order to be big endian")
+	}
+
+	LittleEndian()
+
+	if BinaryOrder() != binary.LittleEndian {
+		t.Error("expected little endian binary order after calling LittleEndian()")
+	}
+
+	BigEndian()
+
+	if BinaryOrder() != binary.BigEndian {
+		t.Error("expected big endian binary order after calling BigEndian()")
+	}
+}
+
+func TestFromWithLengthShortSlicePanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected a panic when the slice is shorter than the requested length")
+		}
+	}()
+
+	FromWithLength(128, []uint64{0})
+}
+
+func TestNewAllocationFailure(t *testing.T) {
+	// New(Cap()) can only be forced to fail its backing allocation on 64-bit
+	// platforms, where Cap() implies an astronomically large slice. On 32-bit
+	// platforms wordsNeeded caps the backing slice at about 512 MiB, which
+	// usually allocates successfully, so the recover path cannot be exercised.
+	if bits.UintSize < 64 {
+		t.Skip("allocation failure cannot be forced on 32-bit platforms")
+	}
+
+	b := New(Cap())
+	if b.Len() != 0 {
+		t.Errorf("expected an empty BitSet on allocation failure, got length %d", b.Len())
+	}
+
+	if b.Count() != 0 {
+		t.Errorf("expected no bits set on allocation failure, got %d", b.Count())
+	}
+}
+
+func TestCompactNoBitsSet(t *testing.T) {
+	b := New(1000)
+	b.Compact()
+
+	if b.Len() != 64 {
+		t.Errorf("expected Compact to preserve one word (64 bits), got length %d", b.Len())
+	}
+
+	if len(b.set) != 1 {
+		t.Errorf("expected a single backing word after Compact, got %d", len(b.set))
+	}
+}
+
+func TestNextClearShortBacking(t *testing.T) {
+	// A degenerate BitSet whose backing slice is shorter than its length
+	// must not panic.
+	b := &BitSet{length: 100, set: []uint64{}}
+
+	idx, found := b.NextClear(0)
+	if found || idx != 0 {
+		t.Errorf("expected (0, false) on a BitSet with a short backing slice, got (%d, %v)", idx, found)
+	}
+}
+
+func TestPreviousClearEarlierWord(t *testing.T) {
+	// The word containing the starting index is all ones, so the search
+	// must continue in the earlier words.
+	b := From([]uint64{^uint64(8), ^uint64(0)})
+
+	idx, found := b.PreviousClear(127)
+	if !found || idx != 3 {
+		t.Errorf("expected (3, true), got (%d, %v)", idx, found)
+	}
+}
+
+func TestCopyFullNilDestination(t *testing.T) {
+	b := New(100)
+	b.Set(5)
+	b.CopyFull(nil) // must be a no-op
+
+	if !b.Test(5) {
+		t.Error("expected the source BitSet to be unchanged")
+	}
+}
+
+func TestCopyFullEmptySource(t *testing.T) {
+	var b BitSet
+
+	c := New(100)
+	c.Set(5)
+	b.CopyFull(c)
+
+	if c.Len() != 0 || c.Count() != 0 {
+		t.Errorf("expected the destination to be emptied, got length %d with %d bits set", c.Len(), c.Count())
+	}
+}
+
+func TestCopyFullReuseCapacity(t *testing.T) {
+	b := From([]uint64{0xFF})
+	c := From([]uint64{0, 0}) // enough capacity, no allocation needed
+	b.CopyFull(c)
+
+	if c.Len() != 64 || len(c.set) != 1 || c.set[0] != 0xFF {
+		t.Errorf("expected an identical copy reusing the existing capacity, got length %d with %d words", c.Len(), len(c.set))
+	}
+}
+
+func TestEqualLengthOverflow(t *testing.T) {
+	// A degenerate length of Cap() makes the internal word count overflow
+	// to zero; Equal must still consider two such BitSets equal.
+	b := &BitSet{length: Cap()}
+
+	c := &BitSet{length: Cap()}
+	if !b.Equal(c) {
+		t.Error("expected two degenerate BitSets of maximal length to be equal")
+	}
+}
+
+func TestInPlaceDifferenceEmptyReceiver(t *testing.T) {
+	b := New(0)
+	compare := New(100)
+	compare.Set(5)
+	b.InPlaceDifference(compare) // must be a no-op
+
+	if b.Count() != 0 {
+		t.Errorf("expected no bits set, got %d", b.Count())
+	}
+}
+
+// failWriter accepts up to limit bytes and then fails.
+type failWriter struct {
+	limit int
+}
+
+func (w *failWriter) Write(p []byte) (int, error) {
+	if len(p) > w.limit {
+		return 0, errors.New("write failed")
+	}
+
+	w.limit -= len(p)
+
+	return len(p), nil
+}
+
+func TestWriteToFailingWriter(t *testing.T) {
+	b := New(64)
+	b.Set(1)
+
+	// Failure while writing the length header.
+	n, err := b.WriteTo(&failWriter{limit: 0})
+	if err == nil {
+		t.Error("expected an error when the length header cannot be written")
+	}
+
+	if n != 0 {
+		t.Errorf("expected 0 bytes written, got %d", n)
+	}
+
+	// Failure while writing the data words.
+	n, err = b.WriteTo(&failWriter{limit: wordBytes})
+	if err == nil {
+		t.Error("expected an error when the data words cannot be written")
+	}
+
+	if n != int64(wordBytes) {
+		t.Errorf("expected %d bytes written, got %d", wordBytes, n)
+	}
+}
+
+func TestReadFromTruncatedStream(t *testing.T) {
+	// A header declaring 64 bits, but no payload.
+	var buf bytes.Buffer
+
+	err := binary.Write(&buf, binaryOrder, uint64(64))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	b := New(0)
+
+	_, err = b.ReadFrom(&buf)
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Errorf("expected io.ErrUnexpectedEOF, got %v", err)
+	}
+
+	if b.Len() != 0 || len(b.set) != 0 {
+		t.Errorf("expected the BitSet to be reset after a read failure, got length %d", b.Len())
+	}
+}
+
+func TestUnmarshalJSONErrors(t *testing.T) {
+	var b BitSet
+
+	err := b.UnmarshalJSON([]byte(`42`))
+	if err == nil {
+		t.Error("expected an error when the JSON value is not a string")
+	}
+
+	err = b.UnmarshalJSON([]byte(`"@invalid@"`))
+	if err == nil {
+		t.Error("expected an error when the string is not valid base64")
+	}
+}
+
+func TestRankBeyondLength(t *testing.T) {
+	b := New(64)
+	b.Set(0)
+	b.Set(63)
+
+	if r := b.Rank(1000); r != 2 {
+		t.Errorf("expected rank 2 for an index beyond the length, got %d", r)
+	}
+}
+
+func TestSelectOutOfRange(t *testing.T) {
+	b := New(100)
+	b.Set(10)
+
+	if s := b.Select(1); s != 100 {
+		t.Errorf("expected the length (100) for an out of range rank, got %d", s)
+	}
+}
+
+func TestShiftEmptyBitSet(t *testing.T) {
+	b := New(100)
+	b.ShiftLeft(5)
+
+	if b.Count() != 0 {
+		t.Errorf("expected no bits set after shifting an empty BitSet left, got %d", b.Count())
+	}
+
+	b.ShiftRight(5)
+
+	if b.Count() != 0 {
+		t.Errorf("expected no bits set after shifting an empty BitSet right, got %d", b.Count())
+	}
+}
+
+func TestShiftLeftExceedsCapacityPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected a panic when the shift exceeds the capacity")
+		}
+	}()
+
+	b := New(2)
+	b.Set(1)
+	b.ShiftLeft(Cap())
+}
+
+func TestExtract(t *testing.T) {
+	b := From([]uint64{0xDA})    // bits 1, 3, 4, 6, 7
+	mask := From([]uint64{0x66}) // bits 1, 2, 5, 6
+	got := b.Extract(mask)
+	// The bits of b at positions 1, 2, 5, 6 are 1, 0, 0, 1: packed 0b1001.
+	if got.set[0] != 0x9 {
+		t.Errorf("expected extracted word 0x9, got %#x", got.set[0])
+	}
+}
+
+func TestDeposit(t *testing.T) {
+	b := From([]uint64{0x9})     // bits 0, 3
+	mask := From([]uint64{0x66}) // bits 1, 2, 5, 6
+	got := b.Deposit(mask)
+	// The bits 0, 1, 2, 3 of b go to positions 1, 2, 5, 6: 0b01000010.
+	if got.set[0] != 0x42 {
+		t.Errorf("expected deposited word 0x42, got %#x", got.set[0])
+	}
+}
+
+func TestExtractToEdgeCases(t *testing.T) {
+	// An empty mask is a no-op.
+	b := From([]uint64{0xDA})
+	dst := New(64)
+	b.ExtractTo(New(0), dst)
+
+	if dst.Count() != 0 {
+		t.Errorf("expected no bits set with an empty mask, got %d", dst.Count())
+	}
+
+	// A destination that is too small is extended, and a mask longer than
+	// the source is truncated.
+	mask := From([]uint64{0x66, 0x1}) // 5 bits over two words, b has one word
+	small := New(0)
+	b.ExtractTo(mask, small)
+
+	if small.Len() != 5 {
+		t.Errorf("expected the destination to be extended to 5 bits, got %d", small.Len())
+	}
+
+	if small.set[0] != 0x9 {
+		t.Errorf("expected extracted word 0x9, got %#x", small.set[0])
+	}
+}
+
+func TestDepositToEdgeCases(t *testing.T) {
+	b := From([]uint64{0x9})
+	mask := From([]uint64{0x66})
+
+	// An empty destination is a no-op.
+	empty := New(0)
+	b.DepositTo(mask, empty)
+
+	if empty.Count() != 0 {
+		t.Errorf("expected no bits set with an empty destination, got %d", empty.Count())
+	}
+
+	// A destination shorter than the mask is truncated.
+	dst := From([]uint64{0})
+	longMask := From([]uint64{0x66, 0xF0})
+	b.DepositTo(longMask, dst)
+
+	if dst.set[0] != 0x42 {
+		t.Errorf("expected deposited word 0x42, got %#x", dst.set[0])
+	}
+}
+
+func TestDepositToShortSource(t *testing.T) {
+	// The mask requires 65 source bits but the source has a single word,
+	// so the deposit must stop after the first word.
+	b := From([]uint64{0xF})
+	mask := From([]uint64{^uint64(0), 0x1})
+	dst := From([]uint64{0, 0})
+	b.DepositTo(mask, dst)
+
+	if dst.set[0] != 0xF {
+		t.Errorf("expected deposited word 0xF, got %#x", dst.set[0])
+	}
+
+	if dst.set[1] != 0 {
+		t.Errorf("expected the second word to be untouched, got %#x", dst.set[1])
+	}
+}

--- a/cmd/pextgen/main_test.go
+++ b/cmd/pextgen/main_test.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"flag"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPextByte(t *testing.T) {
+	cases := []struct {
+		b, m, want uint8
+	}{
+		{0x00, 0x00, 0x00},
+		{0xFF, 0x00, 0x00},
+		{0xAB, 0xFF, 0xAB}, // full mask: identity
+		{0xDA, 0x66, 0x09}, // bits at positions 1, 2, 5, 6 are 1, 0, 0, 1
+		{0x80, 0x80, 0x01},
+	}
+	for _, c := range cases {
+		if got := pextByte(c.b, c.m); got != c.want {
+			t.Errorf("pextByte(%#02x, %#02x) = %#02x, want %#02x", c.b, c.m, got, c.want)
+		}
+	}
+}
+
+func TestPdepByte(t *testing.T) {
+	cases := []struct {
+		b, m, want uint8
+	}{
+		{0x00, 0x00, 0x00},
+		{0xFF, 0x00, 0x00},
+		{0xAB, 0xFF, 0xAB}, // full mask: identity
+		{0x09, 0x66, 0x42}, // bits 0 and 3 go to positions 1 and 6
+		{0x01, 0x80, 0x80},
+	}
+	for _, c := range cases {
+		if got := pdepByte(c.b, c.m); got != c.want {
+			t.Errorf("pdepByte(%#02x, %#02x) = %#02x, want %#02x", c.b, c.m, got, c.want)
+		}
+	}
+}
+
+func TestPextPdepRoundTrip(t *testing.T) {
+	// pdep is the inverse of pext for the bits selected by the mask.
+	for b := 0; b < 256; b++ {
+		for _, m := range []uint8{0x00, 0x0F, 0x55, 0xAA, 0xFF} {
+			extracted := pextByte(uint8(b), m)
+			if got := pdepByte(extracted, m); got != uint8(b)&m {
+				t.Fatalf("pdepByte(pextByte(%#02x, %#02x), %#02x) = %#02x, want %#02x", b, m, m, got, uint8(b)&m)
+			}
+		}
+	}
+}
+
+func TestGenerateTable(t *testing.T) {
+	var single [256]uint8
+
+	single[0] = 1
+
+	out := generateTable("popLUT", single, "population counts")
+	if !strings.Contains(out, "// population counts\n") {
+		t.Errorf("expected the comment in the output, got %q", out[:40])
+	}
+
+	if !strings.Contains(out, "var popLUT = [256]uint8{") {
+		t.Error("expected a [256]uint8 table declaration in the output")
+	}
+
+	if !strings.Contains(out, "1,") {
+		t.Error("expected the table values in the output")
+	}
+
+	var double [256][256]uint8
+
+	double[0][0] = 7
+
+	out = generateTable("pextLUT", double, "")
+	if !strings.Contains(out, "var pextLUT = [256][256]uint8{") {
+		t.Error("expected a [256][256]uint8 table declaration in the output")
+	}
+
+	if !strings.Contains(out, "7,") {
+		t.Error("expected the table values in the output")
+	}
+}
+
+// setArgs replaces the process arguments and resets the flag set so that
+// main() can be invoked more than once.
+func setArgs(t *testing.T, args ...string) {
+	t.Helper()
+
+	oldArgs, oldCommandLine := os.Args, flag.CommandLine
+
+	t.Cleanup(func() {
+		os.Args, flag.CommandLine = oldArgs, oldCommandLine
+	})
+
+	os.Args = args
+	flag.CommandLine = flag.NewFlagSet(args[0], flag.ContinueOnError)
+}
+
+func TestMainMissingPackageName(t *testing.T) {
+	setArgs(t, "pextgen")
+	main() // must return after reporting the missing -pkg flag
+}
+
+func TestMainGeneratesFile(t *testing.T) {
+	dir := t.TempDir()
+
+	oldwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = os.Chdir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		err := os.Chdir(oldwd)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	setArgs(t, "pextgen", "-pkg", "bitset")
+	main()
+
+	data, err := os.ReadFile(filepath.Join(dir, "pext.gen.go"))
+	if err != nil {
+		t.Fatalf("expected main to generate pext.gen.go: %v", err)
+	}
+
+	content := string(data)
+	if !strings.Contains(content, "package bitset") {
+		t.Error("expected the generated file to declare the requested package")
+	}
+
+	for _, table := range []string{"pextLUT", "pdepLUT", "popLUT"} {
+		if !strings.Contains(content, "var "+table+" = ") {
+			t.Errorf("expected the generated file to contain the %s table", table)
+		}
+	}
+}

--- a/example_iter_test.go
+++ b/example_iter_test.go
@@ -1,0 +1,21 @@
+//go:build go1.23
+
+package bitset
+
+import "fmt"
+
+// ExampleBitSet_EachSet iterates over the set bits using a range-over-function
+// loop. This is the most concise way to visit every set bit on Go 1.23+.
+func ExampleBitSet_EachSet() {
+	var b BitSet
+	b.Set(1).Set(2).Set(4).Set(8)
+
+	for i := range b.EachSet() {
+		fmt.Println(i)
+	}
+	// Output:
+	// 1
+	// 2
+	// 4
+	// 8
+}

--- a/example_iter_test.go
+++ b/example_iter_test.go
@@ -1,4 +1,5 @@
 //go:build go1.23
+// +build go1.23
 
 package bitset
 

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,279 @@
+// This file contains runnable, self-verifying examples that double as
+// documentation on https://pkg.go.dev. Every example asserts its output via
+// an "// Output:" comment, so `go test` fails if the behavior ever changes.
+
+package bitset
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// Example gives a tour of the most common operations: creating a set, setting
+// and testing bits, chaining, and querying the population count and length.
+func Example() {
+	// The zero value of a BitSet is an empty set that is ready to use.
+	var b BitSet
+
+	// Set returns the BitSet, so calls can be chained.
+	b.Set(10).Set(11).Set(1000)
+
+	fmt.Println("bit 10 set:", b.Test(10))
+	fmt.Println("bit 500 set:", b.Test(500))
+	fmt.Println("count:", b.Count()) // number of set bits
+	fmt.Println("len:", b.Len())     // one past the highest set bit
+
+	// Output:
+	// bit 10 set: true
+	// bit 500 set: false
+	// count: 3
+	// len: 1001
+}
+
+// ExampleNew shows creating a BitSet with a size hint. The hint avoids
+// re-allocations; the set still grows automatically past the hint if needed.
+func ExampleNew() {
+	b := New(64) // hint: expect to use ~64 bits
+	b.Set(1).Set(2).Set(3)
+	fmt.Println(b.String())
+	// Output: {1,2,3}
+}
+
+// ExampleFrom builds a BitSet directly from packed 64-bit words, which is handy
+// when interoperating with other bitmap representations.
+func ExampleFrom() {
+	// In word 0, bits 0 and 2 are set: 0b101 == 5.
+	b := From([]uint64{0b101})
+	fmt.Println(b.String())
+	// Output: {0,2}
+}
+
+// ExampleBitSet_Set demonstrates chaining, which works because Set (and Clear,
+// Flip, ...) return the receiver.
+func ExampleBitSet_Set() {
+	b := New(100)
+	b.Set(0).Set(1).Set(50)
+	fmt.Println(b.String())
+	// Output: {0,1,50}
+}
+
+// ExampleBitSet_Clear turns an individual bit off.
+func ExampleBitSet_Clear() {
+	b := New(10).Set(1).Set(2).Set(3)
+	b.Clear(2)
+	fmt.Println(b.String())
+	// Output: {1,3}
+}
+
+// ExampleBitSet_Flip toggles a single bit.
+func ExampleBitSet_Flip() {
+	var b BitSet
+	b.Set(0).Set(1)
+	b.Flip(1) // bit 1 was set, so it is cleared
+	b.Flip(2) // bit 2 was clear, so it is set
+	fmt.Println(b.String())
+	// Output: {0,2}
+}
+
+// ExampleBitSet_FlipRange toggles every bit in the half-open range [start, end).
+func ExampleBitSet_FlipRange() {
+	var b BitSet
+	b.FlipRange(0, 5) // sets bits 0,1,2,3,4
+	fmt.Println(b.String())
+	// Output: {0,1,2,3,4}
+}
+
+// ExampleBitSet_Count reports the number of set bits (the cardinality).
+func ExampleBitSet_Count() {
+	b := New(100).Set(3).Set(30).Set(90)
+	fmt.Println(b.Count())
+	// Output: 3
+}
+
+// ExampleBitSet_NextSet is the idiomatic way to iterate over the set bits in
+// ascending order on any Go version.
+func ExampleBitSet_NextSet() {
+	b := New(100).Set(0).Set(2).Set(4).Set(80)
+
+	var set []uint
+	for i, ok := b.NextSet(0); ok; i, ok = b.NextSet(i + 1) {
+		set = append(set, i)
+	}
+
+	fmt.Println(set)
+	// Output: [0 2 4 80]
+}
+
+// ExampleBitSet_NextSetMany retrieves many set bits at once into a reusable
+// buffer, which is useful for batching in hot loops.
+func ExampleBitSet_NextSetMany() {
+	b := New(100).Set(1).Set(2).Set(3).Set(70).Set(99)
+
+	buf := make([]uint, 4) // fetch at most 4 bits per call
+	_, set := b.NextSetMany(0, buf)
+
+	fmt.Println(set)
+	// Output: [1 2 3 70]
+}
+
+// ExampleBitSet_NextClear finds the first clear (unset) bit at or after i.
+func ExampleBitSet_NextClear() {
+	b := New(10).Set(0).Set(1).Set(2)
+
+	i, ok := b.NextClear(0)
+	fmt.Println(i, ok)
+	// Output: 3 true
+}
+
+// ExampleBitSet_Union returns a new set containing every bit set in either set.
+func ExampleBitSet_Union() {
+	a := New(10).Set(1).Set(2).Set(3)
+	b := New(10).Set(3).Set(4).Set(5)
+	fmt.Println(a.Union(b).String())
+	// Output: {1,2,3,4,5}
+}
+
+// ExampleBitSet_Intersection returns a new set containing the bits set in both.
+func ExampleBitSet_Intersection() {
+	a := New(10).Set(1).Set(2).Set(3)
+	b := New(10).Set(3).Set(4).Set(5)
+	fmt.Println(a.Intersection(b).String())
+	// Output: {3}
+}
+
+// ExampleBitSet_Difference returns the bits set in a but not in b.
+func ExampleBitSet_Difference() {
+	a := New(10).Set(1).Set(2).Set(3)
+	b := New(10).Set(3).Set(4).Set(5)
+	fmt.Println(a.Difference(b).String())
+	// Output: {1,2}
+}
+
+// ExampleBitSet_SymmetricDifference returns the bits set in exactly one of the
+// two sets.
+func ExampleBitSet_SymmetricDifference() {
+	a := New(10).Set(1).Set(2).Set(3)
+	b := New(10).Set(3).Set(4).Set(5)
+	fmt.Println(a.SymmetricDifference(b).String())
+	// Output: {1,2,4,5}
+}
+
+// ExampleBitSet_Complement flips every bit within the set's length.
+func ExampleBitSet_Complement() {
+	b := New(8).Set(1).Set(3)
+	fmt.Println(b.Complement().String())
+	// Output: {0,2,4,5,6,7}
+}
+
+// ExampleBitSet_InPlaceUnion mutates the receiver instead of allocating a new
+// set. The In-Place variants (and the *Cardinality helpers) avoid allocation in
+// performance-sensitive code.
+func ExampleBitSet_InPlaceUnion() {
+	a := New(10).Set(1).Set(2)
+	b := New(10).Set(2).Set(3)
+	a.InPlaceUnion(b)
+	fmt.Println(a.String())
+	// Output: {1,2,3}
+}
+
+// ExampleBitSet_Any shows the emptiness predicates. All, Any and None answer
+// "are all/any/no bits set?".
+func ExampleBitSet_Any() {
+	var b BitSet
+	fmt.Println("any:", b.Any())   // empty set
+	fmt.Println("none:", b.None()) // empty set
+	b.Set(5)
+	fmt.Println("any after Set:", b.Any())
+	// Output:
+	// any: false
+	// none: true
+	// any after Set: true
+}
+
+// ExampleBitSet_IsSuperSet reports whether every bit of other is also set here.
+func ExampleBitSet_IsSuperSet() {
+	super := New(10).Set(1).Set(2).Set(3)
+	sub := New(10).Set(1).Set(3)
+	fmt.Println(super.IsSuperSet(sub))
+	// Output: true
+}
+
+// ExampleBitSet_String renders the set in mathematical set notation.
+func ExampleBitSet_String() {
+	b := New(50).Set(1).Set(17).Set(49)
+	fmt.Println(b.String())
+	// Output: {1,17,49}
+}
+
+// ExampleBitSet_Rank counts how many bits are set at or below the given index.
+func ExampleBitSet_Rank() {
+	b := New(10).Set(1).Set(3).Set(5)
+	fmt.Println(b.Rank(0)) // no bit <= 0 is set
+	fmt.Println(b.Rank(3)) // bits 1 and 3
+	fmt.Println(b.Rank(9)) // bits 1, 3 and 5
+	// Output:
+	// 0
+	// 2
+	// 3
+}
+
+// ExampleBitSet_Select returns the index of the j-th set bit (0-indexed).
+func ExampleBitSet_Select() {
+	b := New(10).Set(1).Set(3).Set(5)
+	fmt.Println(b.Select(0)) // first set bit
+	fmt.Println(b.Select(1)) // second set bit
+	fmt.Println(b.Select(2)) // third set bit
+	// Output:
+	// 1
+	// 3
+	// 5
+}
+
+// ExampleBitSet_WriteTo serializes a BitSet to a stream and reads it back with
+// ReadFrom. The encoding is portable across platforms.
+func ExampleBitSet_WriteTo() {
+	b := New(100).Set(10).Set(20).Set(99)
+
+	var buf bytes.Buffer
+
+	_, err := b.WriteTo(&buf)
+	if err != nil {
+		panic(err)
+	}
+
+	// ReadFrom reuses the receiver's storage where possible.
+	restored := New(0)
+
+	_, err = restored.ReadFrom(&buf)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("equal:", restored.Equal(b))
+	fmt.Println("bits:", restored.String())
+	// Output:
+	// equal: true
+	// bits: {10,20,99}
+}
+
+// ExampleBitSet_MarshalJSON round-trips a BitSet through JSON. BitSet
+// implements json.Marshaler and json.Unmarshaler.
+func ExampleBitSet_MarshalJSON() {
+	b := New(20).Set(0).Set(19)
+
+	data, err := json.Marshal(b)
+	if err != nil {
+		panic(err)
+	}
+
+	var restored BitSet
+
+	err = json.Unmarshal(data, &restored)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(restored.String())
+	// Output: {0,19}
+}


### PR DESCRIPTION
## Summary

This PR is test-only — it adds no production code and changes no behavior. It substantially raises coverage and adds runnable documentation:

- `bitset_test.go` — error-path and edge-case tests for the core package: binary-order selection (`BinaryOrder`/`LittleEndian`/`BigEndian`), `FromWithLength` short-slice panic, `New` allocation failure, `Compact` with no bits set, `NextClear`/`PreviousClear` boundaries, `CopyFull` (nil/empty/capacity reuse), `Equal` length overflow, `InPlaceDifference` empty receiver, `WriteTo`/`ReadFrom` failures, `UnmarshalJSON` errors, `Rank`/`Select` out-of-range, shift limits, and the `Extract`/`Deposit`/`ExtractTo`/`DepositTo` edge cases.
- `cmd/pextgen/main_test.go` — tests for the `pextByte`/`pdepByte` helpers, their round-trip property, `generateTable`, and `main`'s flag handling and file generation.
- `bitset_iter_test.go` — `TestIterEarlyStop`, verifying `EachSet` stops cleanly when the consumer `break`s early.
- `example_test.go` / `example_iter_test.go` — self-verifying godoc examples for the common `BitSet` operations and a `go1.23` `EachSet` example (build-tagged so pre-1.23 builds are unaffected).

## Coverage impact

| Package | Before | After |
| --- | --- | --- |
| `bits-and-blooms/bitset` | 94.9% | 99.6% |
| `cmd/pextgen` | 0.0% (no test file) | 94.2% |

## Why this is needed

1. **Error and edge-case paths in the core package were the coverage gap.** The bulk of the previously-untested code was defensive branches — allocation failure, truncated/failed I/O, malformed JSON, out-of-range `Rank`/`Select`, degenerate lengths, and the extract/deposit boundaries. These are exactly the paths that are hardest to exercise by accident and most costly to regress silently, so they now have targeted tests. This lifts the core package from 94.9% to 99.6%.
2. **`cmd/pextgen` had 0% coverage.** This command generates the PEXT/PDEP lookup tables the library ships with — it is part of the build/codegen toolchain, so a silent bug there can corrupt generated tables and, in turn, the population-count/extract paths. It now sits at 94.2%, including a round-trip property test (`pdep(pext(x, m), m) == x & m`) that pins down the core invariant.
3. **The `EachSet` early-`break` path was untested.** Range-over-function iterators only behave correctly if the yield function's `false` return is honored. `TestIterEarlyStop` guards against a regression where breaking out of the loop early would over-iterate or misbehave.
4. **The examples double as compiler-checked documentation.** Each `Example*` has an `// Output:` assertion, so `go test` fails if the documented behavior ever drifts. They also render on pkg.go.dev, improving the library's onboarding docs at zero maintenance cost.

## Risk

None to production. No non-test file is touched; the new `go1.23` example is build-tagged so older toolchains are unaffected. `go test ./...` passes.
