### PR TITLE
ci: modernize workflows — pin actions to SHAs, enable Go caching, widen test matrix

### DIFF
--- a/.github/workflows/legacy86.yaml
+++ b/.github/workflows/legacy86.yaml
@@ -1,5 +1,10 @@
 name: Go-legacy-CI
+
 on: [push, pull_request]
+
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -7,12 +12,11 @@ jobs:
       matrix:
         go-version: ['1.20.x', '1.21.x']
     steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: ${{ matrix.go-version }}
-      - name: Checkout code
-        uses: actions/checkout@v6.0.2
       - name: Test on 386
-        run: |
-          GOARCH=386 go test
+        run: GOARCH=386 go test ./...

--- a/.github/workflows/legacy86.yaml
+++ b/.github/workflows/legacy86.yaml
@@ -18,5 +18,6 @@ jobs:
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: ${{ matrix.go-version }}
+          cache: true
       - name: Test on 386
         run: GOARCH=386 go test ./...

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,16 +29,16 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.2.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Configure Pages
-        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       - name: Upload site artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: docs
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v4.3.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -59,7 +59,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: SARIF file
           path: results.sarif
@@ -67,6 +67,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@8e0b1c74b1d5a0077b04d064c76ee714d3da7637 # v2.14.6
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           sarif_file: results.sarif

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,15 +7,15 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.16.x, 1.17.x, 1.18.x, 1.19.x,1.20.x,1.21.x,1.22.x,1.23.x,1.24.x]
+        go-version: [1.16.x, 1.17.x, 1.18.x, 1.19.x,1.20.x,1.21.x,1.22.x,1.23.x,1.24.x,1.25.x,1.26.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Install Go
-      uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c #v6.1.0
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
       with:
         go-version: ${{ matrix.go-version }}
     - name: Checkout code
-      uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 #v4.0.0
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - name: Test
       run: go test ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
       uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
       with:
         go-version: ${{ matrix.go-version }}
+        cache: true
     - name: Checkout code
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - name: Test


### PR DESCRIPTION
## Summary

Housekeeping pass over the GitHub Actions workflows to improve supply-chain security, CI speed, and Go version coverage. No library code changes.

## Changes & rationale

- **Pin actions to full commit SHAs at their latest releases.** Updated checkout → v7.0.0, setup-go → v6.5.0, configure-pages → v6.0.0, upload-pages-artifact → v5.0.0, deploy-pages → v5.0.0, upload-artifact → v7.0.1, and codeql-action/upload-sarif → v4.37.0. *Why:* pinning by SHA (rather than a mutable tag like `@v6`) prevents a compromised or retagged action from silently running in CI, which is exactly what the Scorecard workflow flags. Staying on current releases keeps us off deprecated Node runtimes and EOL action versions.

- **Add explicit least-privilege permissions to `legacy86.yaml`.** Set `permissions: contents: read` so the token can't do more than checkout requires. *Why:* the other workflows already scope their tokens; this closes the remaining gap and follows the principle of least privilege.

- **Enable Go build/module caching (`cache: true`) in the test and legacy86 workflows.** *Why:* faster, cheaper CI runs by reusing the module and build cache between runs, especially across the large OS × Go-version matrix.

- **Extend the test matrix with Go 1.25.x and 1.26.x.** *Why:* verify the package builds and passes on the newest Go releases so we catch regressions early.

- **Run `go test ./...` instead of `go test`.** *Why:* the bare command only tests the root package; `./...` covers all packages (e.g. `cmd/pextgen`) so nothing is silently skipped.
